### PR TITLE
update disk check

### DIFF
--- a/roles/openshift_health_checker/openshift_checks/disk_availability.py
+++ b/roles/openshift_health_checker/openshift_checks/disk_availability.py
@@ -12,7 +12,7 @@ class DiskAvailability(NotContainerizedMixin, OpenShiftCheck):
     # Values taken from the official installation documentation:
     # https://docs.openshift.org/latest/install_config/install/prerequisites.html#system-requirements
     recommended_disk_space_bytes = {
-        "masters": 40 * 10**9,
+        "masters": 28 * 10**9,
         "nodes": 15 * 10**9,
         "etcd": 20 * 10**9,
     }


### PR DESCRIPTION
Update disk check for master VM from 40 GB to 28 GB as in Azure, VM disk size is 32 GB and it fails to complete the deployment with below error.

  1. Host:     aacl-master-0  (Standard_D4_v2)
     Play:     Verify Requirements
     Task:     openshift_health_check
     Message:  One or more checks failed
     Details:  check "disk_availability":
               **Available disk space (29.6 GB) for the volume containing "/var" is below minimum recommended space (40.0 GB)**